### PR TITLE
Fix backend CAPTCHA form using invalid class

### DIFF
--- a/app/design/adminhtml/default/default/template/captcha/recaptcha.phtml
+++ b/app/design/adminhtml/default/default/template/captcha/recaptcha.phtml
@@ -1,7 +1,7 @@
 <?php $captcha = $this->getCaptchaModel() ?>
 <?php $theme = $captcha->getTheme(); ?>
 
-<li id="<?php echo $captcha->getElementId(); ?>">
+<li id="<?php echo $captcha->getElementId(); ?>" style="list-style: none">
     <div id="<?php echo $captcha->getElementId('container'); ?>" class='proxiblue-recaptcha captcha-image-box-<?php echo $this->getFormId(); ?>'></div>
 </li>
 
@@ -19,7 +19,7 @@
                         if (!form) {
                             return;
                         }
-                        var varienForm = new VarienForm(form.id);
+                        var adminVarienForm = new varienForm(form.id);
                         var cpatchaId = grecaptcha.render(elm.id, {
                             <?php if($theme == 'invisible'):?>
                             "size": "invisible",
@@ -57,7 +57,7 @@
                              */
                             if(window.recaptchaHasInterceptedFormSubmit != 1) {
                                 e.preventDefault();
-                                if (varienForm.validator.validate()) {
+                                if (adminVarienForm.validator.validate()) {
                                     window.parentMehod = function () {
                                         form.submit()
                                     };
@@ -73,7 +73,7 @@
                     });
 
                 <?php if($theme == 'invisible'):?>
-                VarienForm.prototype.submit = VarienForm.prototype.submit.wrap(function (parentMethod) {
+                varienForm.prototype.submit = varienForm.prototype.submit.wrap(function (parentMethod) {
                     window.parentMehod = parentMethod;
                     if (this.validator && this.validator.validate()) {
                         // this captures the main login form on checkout, potentially others on site


### PR DESCRIPTION
On line 22 the file tries to declare a `new VarienForm`, but this fails because this class does not exist in the backend.  Mage backend uses `js/mage/adminhtml/form.js` for form validation, NOT `js/varien/form.js`.  The latter declares `VarienForm` but the former declares `varienForm`.  Therefore in the backend class `varienForm` must be used.  

Additionally line 22 tries to initialise a variable *called* `varienForm`, which is already declared as a class by `js/mage/adminhtml/form.js`.  Therefore I changed this variable to `adminVarienForm` here, and on line 60 where it is used.

On line 76 the correct declared `varienForm` is used, rather than `VarienForm` which is undefined in the backend.

The above errors stop admin login with reCaptcha enabled from functioning.

Lastly, on line 4, some inline CSS is added to prevent a rogue bullet appearing on the admin form.